### PR TITLE
Returns prefix information on e164 lookup.

### DIFF
--- a/e164.js
+++ b/e164.js
@@ -640,18 +640,50 @@ var lookup, prefixes = {
   "998": [ "UZ", "Uzbekistan" ]
 };
 
-lookup = function(phone) {
-  if (phone.length) {
-    var prefix, c = phone.length;
-    for (c; c >= 0; c=c-1) {
-      prefix = phone.substring(0, c);
-      if (prefixes[prefix]) {
-        return { country: prefixes[prefix][1], code: prefixes[prefix][0] };
-      }
+numbersOnly = function(phone) {
+  return phone.replace('+', '');
+};
+
+isSupportedPrefix = function(prefix) {
+  return !!prefixes[prefix];
+};
+
+getPrefix = function(phone) {
+  var prefix, c = phone.length;
+  for (c; c >= 0; c=c-1) {
+    prefix = phone.substring(0, c);
+    if (isSupportedPrefix(prefix)) {
+      return prefix;
     }
   }
 };
 
+getCountryName = function(prefix) {
+  return isSupportedPrefix(prefix) && prefixes[prefix][1];
+};
+
+getCountryCode = function(prefix) {
+  return isSupportedPrefix(prefix) && prefixes[prefix][0];
+};
+
+getPrefixInfo = function(prefix) {
+  return {
+    prefix: prefix,
+    country: getCountryName(prefix),
+    code: getCountryCode(prefix),
+  };
+};
+
+lookup = function(phone) {
+  if (!phone) {
+    return;
+  }
+  var parsedPhone = numbersOnly(phone);
+  var prefix = getPrefix(parsedPhone);
+  if (prefix) {
+    return getPrefixInfo(prefix);
+  }
+};
 
 
 if (typeof exports !== "undefined"){

--- a/e164.js
+++ b/e164.js
@@ -641,7 +641,7 @@ var lookup, prefixes = {
 };
 
 numbersOnly = function(phone) {
-  return phone.replace('+', '');
+  return phone.split(/[^\d]/).join('');
 };
 
 isSupportedPrefix = function(prefix) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Pascal Deschenes <pdeschen@rassemblr.com> (http://blog.rassemblr.com)",
   "name": "e164",
   "description": "lookup country name given international phone number e164 format.",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "keywords": [
     "phone",
     "country",

--- a/test/test.js
+++ b/test/test.js
@@ -4,15 +4,16 @@
 
 var e164 = require('../e164'), assert = require('assert');
 
-assert.deepEqual({country: "Canada", code: "CA"}, e164.lookup('15141234567'));
-assert.deepEqual({country: "Toll Free", code: "US"}, e164.lookup('18001231234'));
-assert.deepEqual({country: "United States", code: "US"}, e164.lookup('18703434345'));
-assert.deepEqual({country: "India", code: "IN"}, e164.lookup('9191'));
-assert.deepEqual({country: "Norfolk Island", code: "NF"}, e164.lookup('672322424'));
-assert.deepEqual({country: "ICO Global (Mobile Satellite Service)", code: "ZZ"}, e164.lookup('88112311'));
-assert.deepEqual({country: "Canada", code: "CA"}, e164.lookup('1418'));
-assert.deepEqual({country: "United States", code: "US"}, e164.lookup('1603'));
-assert.deepEqual({country: "Malaysia", code: "MY"}, e164.lookup('603'));
+assert.deepEqual({prefix: '1514', country: "Canada", code: "CA"}, e164.lookup('15141234567'));
+assert.deepEqual({prefix: '1514', country: "Canada", code: "CA"}, e164.lookup('+15141234567'));
+assert.deepEqual({prefix: '1800', country: "Toll Free", code: "US"}, e164.lookup('18001231234'));
+assert.deepEqual({prefix: '1870', country: "United States", code: "US"}, e164.lookup('18703434345'));
+assert.deepEqual({prefix: '91', country: "India", code: "IN"}, e164.lookup('9191'));
+assert.deepEqual({prefix: '6723', country: "Norfolk Island", code: "NF"}, e164.lookup('672322424'));
+assert.deepEqual({prefix: '8811', country: "ICO Global (Mobile Satellite Service)", code: "ZZ"}, e164.lookup('88112311'));
+assert.deepEqual({prefix: '1418', country: "Canada", code: "CA"}, e164.lookup('1418'));
+assert.deepEqual({prefix: '1603', country: "United States", code: "US"}, e164.lookup('1603'));
+assert.deepEqual({prefix: '60', country: "Malaysia", code: "MY"}, e164.lookup('603'));
 assert.deepEqual(undefined, e164.lookup('0'));
 
 console.log("ok");


### PR DESCRIPTION
Why not return the e164 prefix which matches as part of the lookup return value? It seems pretty useful to me in order to avoid duplicating that logic on the caller side in case one needs to know the prefix part of a phone number.

@dalyons 
